### PR TITLE
Fix wp_debug irritants

### DIFF
--- a/sample/docker-compose.yml
+++ b/sample/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - WORDPRESS_DB_PASSWORD=wordpress
       - WORDPRESS_DB_NAME=wordpress
       - WORDPRESS_DEBUG=1
+      - WORDPRESS_DEBUG_LOG=1
+      - WORDPRESS_DEBG_DISPLAY=0
     #      - WORDPRESS_AUTH_KEY=
     #      - WORDPRESS_SECURE_AUTH_KEY=
     #      - WORDPRESS_LOGGED_IN_KEY=

--- a/versions/6-php7.4/wp-config-docker.php
+++ b/versions/6-php7.4/wp-config-docker.php
@@ -110,7 +110,9 @@ $table_prefix = getenv_docker('WORDPRESS_TABLE_PREFIX', 'wp_');
  *
  * @link https://wordpress.org/support/article/debugging-in-wordpress/
  */
-define( 'WP_DEBUG', !!getenv_docker('WORDPRESS_DEBUG', '') );
+define( 'WP_DEBUG', !!getenv_docker('WORDPRESS_DEBUG', false) );
+define( 'WP_DEBUG_LOG', !!getenv_docker('WORDPRESS_DEBUG_LOG', false) );
+define( 'WP_DEBUG_DISPLAY', !!getenv_docker('WORDPRESS_DEBUG_DISPLAY', false) );
 
 /* Add any custom values between this line and the "stop editing" line. */
 


### PR DESCRIPTION
Enable all wp_debug options to be set by env variables; set good dev defaults